### PR TITLE
aws.config endpoint for localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ By setting the environment variable "SSMPS_BASE_PATH", the plugin gets the value
 If you set the "SSMPS_BASE_PATH" environment variable, the specified path in the template will be treated as a relative path if it doesn't have a leading slash. The specified path starting with a slash in the template is always treated as an absolute path. So, if you use environment specific values with the SSMPS_BASE_PATH but you want to use some environment agnostic value, you can always specify an absolute path.
 
 Please note that if you don't set the "SSMPS_BASE_PATH" but the specified path in the template doesn't have a leading slash, it will still be treated as an absolute path. So, please be careful if you set a base path while the existing template uses paths in a relative path format.
+
+### Custom Endpoint
+
+You can use the environment variable `SSMPS_AWS_SSM_ENDPOINT` to override the default endpoint used for AWS requests.

--- a/main.go
+++ b/main.go
@@ -35,10 +35,9 @@ func main() {
 			awsRegion = aws.String(ec2Region)
 		}
 	}
-
 	svc := ssm.New(sess, &aws.Config{
 		Region: awsRegion,
-		Endpoint: aws.String(os.Getenv("AWS_ENDPOINT_URL")),
+		Endpoint: aws.String(os.Getenv("SSM_ENDPOINT_URL")),
 	})
 
 	basePath := os.Getenv("SSMPS_BASE_PATH")

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
 const version = "0.1.1"
@@ -22,19 +21,9 @@ func main() {
 	if !validateArgs(os.Args) {
 		os.Exit(1)
 	}
-	var config aws.Config
-	endpoint := os.Getenv("LOCALSTACK_ENDPOINT")
-	if (endpoint != "") {
-		config = aws.Config{
-			Region:           aws.String(os.Getenv("AWS_REGION")),
-			Credentials:      credentials.NewStaticCredentials("test", "test", ""),
-			S3ForcePathStyle: aws.Bool(true),
-			Endpoint:         aws.String(endpoint),
-		  }
-	}
+
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
-		Config: config,
 	}))
 
 	var awsRegion *string
@@ -49,6 +38,7 @@ func main() {
 
 	svc := ssm.New(sess, &aws.Config{
 		Region: awsRegion,
+		Endpoint: aws.String(os.Getenv("AWS_ENDPOINT_URL")),
 	})
 
 	basePath := os.Getenv("SSMPS_BASE_PATH")

--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func main() {
 		}
 	}
 	svc := ssm.New(sess, &aws.Config{
-		Region: awsRegion,
-		Endpoint: aws.String(os.Getenv("SSM_ENDPOINT_URL")),
+		Region:   awsRegion,
+		Endpoint: aws.String(os.Getenv("SSMPS_AWS_SSM_ENDPOINT")),
 	})
 
 	basePath := os.Getenv("SSMPS_BASE_PATH")
@@ -196,7 +196,7 @@ func getMultipleParamValues(svc ssmiface.SSMAPI, names []string) (map[string]str
 		if err != nil {
 			aerr, ok := err.(awserr.Error)
 			if ok {
-				return nil, fmt.Errorf("ssmps returned error: %s message: %s", aerr.Code(), aerr.Message())
+				return nil, fmt.Errorf("ssmps returned error: %s, message: %s", aerr.Code(), aerr.Message())
 			}
 			return nil, fmt.Errorf("ssmps returned unknown error: %s", err)
 		}


### PR DESCRIPTION
I plan to use `LOCALSTACK_ENDPOINT` environment variable to connect to LocalStack.  

The below is from a Localstack documentation for GO to connect to LocalStack here https://docs.localstack.cloud/integrations/sdks/go/